### PR TITLE
PVCTools_alpha_v2.5

### DIFF
--- a/PVCTools_alpha_v2.5/Makefile
+++ b/PVCTools_alpha_v2.5/Makefile
@@ -1,0 +1,38 @@
+DIR_INC = ./include
+DIR_HEAD_SRC = ./src/headnode
+DIR_CHILD_SRC = ./src/childnode
+DIR_HEAD_OBJ = ./obj/headnode
+DIR_CHILD_OBJ = ./obj/childnode
+DIR_BIN = ./bin
+
+HEAD_SRC = $(wildcard ${DIR_HEAD_SRC}/*.cpp)
+HEAD_OBJ = $(patsubst %.cpp,${DIR_HEAD_OBJ}/%.o,$(notdir ${HEAD_SRC}))
+CHILD_SRC = $(wildcard ${DIR_CHILD_SRC}/*.cpp)
+CHILD_OBJ = $(patsubst %.cpp,${DIR_CHILD_OBJ}/%.o,$(notdir ${CHILD_SRC}))
+
+HEAD_TARGET = PCVTools
+CHILD_TARGET = $(DIR_BIN)/main
+TARGET = $(HEAD_TARGET) $(CHILD_TARGET)
+
+CC = g++
+CFLAGS = -g -Wall -fopenmp -I${DIR_INC} -MMD -MT $@ -MF $@.d
+
+all: $(TARGET)
+	@echo "--------The installation has been completed!---------"
+
+${HEAD_TARGET}:${HEAD_OBJ}
+	$(CC) -fopenmp -MMD -MT $@ -MF $@.d $(HEAD_OBJ)  -o $@
+
+${DIR_HEAD_OBJ}/%.o:${DIR_HEAD_SRC}/%.cpp
+	$(CC) $(CFLAGS) -c  $< -o $@
+
+${CHILD_TARGET}:${CHILD_OBJ}
+	$(CC) -fopenmp -MMD -MT $@ -MF $@.d $(CHILD_OBJ)  -o $@
+
+${DIR_CHILD_OBJ}/%.o:${DIR_CHILD_SRC}/%.cpp
+	$(CC) $(CFLAGS) -c  $< -o $@
+
+.PHONY:clean
+clean:
+	rm -fr $(DIR_HEAD_OBJ)/*.o
+	rm -fr $(DIR_CHILD_OBJ)/*.o

--- a/PVCTools_alpha_v2.5/config
+++ b/PVCTools_alpha_v2.5/config
@@ -1,0 +1,3 @@
+<PATH_SAMTOOLS>	=	/gpfs01/software/bio/samtools-1.3.1/samtools
+<PATH_BCFTOOLS>	=	/gpfs01/software/bio/bcftools-1.2/bcftools
+<PATH_BAMUTIL>	=	/gpfs01/home/dshhu/software/bamUtil/bin/./bam

--- a/PVCTools_alpha_v2.5/include/Environment.h
+++ b/PVCTools_alpha_v2.5/include/Environment.h
@@ -1,0 +1,21 @@
+//
+// Created by liujiajun on 2017/4/23.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_ENVIRONMENT_H
+#define PVCTOOLS_ALPHA_V2_0_ENVIRONMENT_H
+
+#include "main.h"
+
+#define FILE_LINE 16383
+#define CMD_NUM 2048
+
+int PrintEvmt();
+
+int SetToolsPath(const char *order, const char *path);
+
+int GetToolsPath(char *path, const char *order);
+
+int SetEvmt(int argc, char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_ENVIRONMENT_H

--- a/PVCTools_alpha_v2.5/include/SegmentBAM.h
+++ b/PVCTools_alpha_v2.5/include/SegmentBAM.h
@@ -1,0 +1,15 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SEGMENTBAM_H
+#define PVCTOOLS_ALPHA_V2_0_SEGMENTBAM_H
+
+#include "main.h"
+#include "Environment.h"
+
+void Modify(char *buffer, char *chrname, int chrname_len, long addresses_number);
+int Sam_Address_Modify(char *file_name, const char *ChrName, long address_count);
+int SegmentBAM(int argc, char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SEGMENTBAM_H

--- a/PVCTools_alpha_v2.5/include/SegmentFA.h
+++ b/PVCTools_alpha_v2.5/include/SegmentFA.h
@@ -1,0 +1,13 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SEGMENTFA_H
+#define PVCTOOLS_ALPHA_V2_0_SEGMENTFA_H
+
+#include "main.h"
+#include "Environment.h"
+
+int SegmentFA(int argc,char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SEGMENTFA_H

--- a/PVCTools_alpha_v2.5/include/SmallFA.h
+++ b/PVCTools_alpha_v2.5/include/SmallFA.h
@@ -1,0 +1,19 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SMALLFA_H
+#define PVCTOOLS_ALPHA_V2_0_SMALLFA_H
+
+#include <iostream>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <omp.h>
+#include <time.h>
+#include "main.h"
+
+int SmallFA(int argc, char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SMALLFA_H

--- a/PVCTools_alpha_v2.5/include/SplitBAM.h
+++ b/PVCTools_alpha_v2.5/include/SplitBAM.h
@@ -1,0 +1,13 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SPLITBAM_H
+#define PVCTOOLS_ALPHA_V2_0_SPLITBAM_H
+
+#include "main.h"
+#include "Environment.h"
+
+int SplitBAM(int argc,char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SPLITBAM_H

--- a/PVCTools_alpha_v2.5/include/SplitFA.h
+++ b/PVCTools_alpha_v2.5/include/SplitFA.h
@@ -1,0 +1,15 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SPLITFA_H
+#define PVCTOOLS_ALPHA_V2_0_SPLITFA_H
+
+#include "main.h"
+#include "Environment.h"
+
+void Fa_Chr(char *workpath, char *fa_path);
+
+int SplitFA(int argc,char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SPLITFA_H

--- a/PVCTools_alpha_v2.5/include/StitchVCF.h
+++ b/PVCTools_alpha_v2.5/include/StitchVCF.h
@@ -1,0 +1,17 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_STITCHVCF_H
+#define PVCTOOLS_ALPHA_V2_0_STITCHVCF_H
+
+#include "main.h"
+#include "Environment.h"
+
+int VCF_Link(char *tarfile, char *formfile, const char *ChrName, long add_count);
+
+void VCF_Modify(char *buffer, const char *chrname, int chrname_len, long addresses_number);
+
+int StitchVCF(int argc,char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_STITCHVCF_H

--- a/PVCTools_alpha_v2.5/include/Submit.h
+++ b/PVCTools_alpha_v2.5/include/Submit.h
@@ -1,0 +1,13 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_SUBMIT_H
+#define PVCTOOLS_ALPHA_V2_0_SUBMIT_H
+
+#include "main.h"
+#include "Environment.h"
+
+int Submit(int argc, char *argv[]);
+
+#endif //PVCTOOLS_ALPHA_V2_0_SUBMIT_H

--- a/PVCTools_alpha_v2.5/include/WriteScript.h
+++ b/PVCTools_alpha_v2.5/include/WriteScript.h
@@ -1,0 +1,8 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_WRITESCRIPT_H
+#define PVCTOOLS_ALPHA_V2_0_WRITESCRIPT_H
+
+#endif //PVCTOOLS_ALPHA_V2_0_WRITESCRIPT_H

--- a/PVCTools_alpha_v2.5/include/main.h
+++ b/PVCTools_alpha_v2.5/include/main.h
@@ -1,0 +1,22 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+#ifndef PVCTOOLS_ALPHA_V2_0_MAIN_H
+#define PVCTOOLS_ALPHA_V2_0_MAIN_H
+
+#include <iostream>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <dirent.h>
+#include <omp.h>
+#include <time.h>
+#include <limits.h>
+#include <algorithm>
+#include <unistd.h>
+
+
+
+#endif //PVCTOOLS_ALPHA_V2_0_MAIN_H

--- a/PVCTools_alpha_v2.5/src/childnode/Environment.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/Environment.cpp
@@ -1,0 +1,125 @@
+//
+// Created by liujiajun on 2017/4/23.
+//
+
+#include "Environment.h"
+
+int PrintEvmt()
+{
+    FILE *fp;
+    if ((fp = fopen("config", "r")) == NULL)
+        exit(-1);
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp))
+    {
+        getline(&Buffer,&Len,fp);
+        std::cout << Buffer << std::endl;
+    }
+    fclose(fp);
+    printf("\n");
+    return 0;
+}
+
+int SetToolsPath(const char *order, const char *path)
+{
+    FILE *fp_f, *fp_t;
+    if ((fp_f = fopen("config", "r")) == NULL)
+        exit(-1);
+    if ((fp_t = fopen("config_tmp", "w")) == NULL)
+        exit(-1);
+    std::string cmd = order;
+    std::transform(cmd.begin() + 1, cmd.end(), cmd.begin(), toupper);
+    cmd.at(cmd.size() - 1) = '\0';
+    char Command[CMD_NUM];
+    snprintf(Command, CMD_NUM, "<PATH_%s>\t=\t", cmd.c_str());
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp_f))
+    {
+        getline(&Buffer,&Len,fp_f);
+        if(strstr(Buffer, Command) != NULL)
+        {
+            int count = 0;
+            for (int i = 0; i < (int)strlen(Buffer); i++)
+            {
+                if (Buffer[i] == '\t')
+                {
+                    count++;
+                }
+                if (count == 2)
+                {
+                    strncat(Command, path, strlen(path));
+                    snprintf(Buffer, strlen(Command) + 2, "%s\n", Command);
+                    break;
+                }
+            }
+        }
+        fputs(Buffer, fp_t);
+    }
+    fclose(fp_f);
+    fclose(fp_t);
+    remove("config");
+    rename("config_tmp", "config");
+    return 0;
+}
+
+int GetToolsPath(char *path, const char *order)
+{
+    FILE *fp;
+    if ((fp = fopen("config", "r")) == NULL)
+    {
+        printf("config打开失败\n");
+        exit(-1);
+    }
+    std::string cmd = order;
+    std::transform(cmd.begin() + 1, cmd.end(), cmd.begin(), toupper);
+    cmd.at(cmd.size() - 1) = '\0';
+    char Command[CMD_NUM];
+    snprintf(Command, CMD_NUM, "<PATH_%s>\t=\t", cmd.c_str());
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp))
+    {
+        getline(&Buffer,&Len,fp);
+        if(strstr(Buffer, Command) != NULL)
+        {
+            int count = 0;
+            for (int i = 0; i < (int)strlen(Buffer); i++)
+            {
+                if (Buffer[i] == '\t')
+                {
+                    count++;
+                }
+                if (count == 2)
+                {
+                    snprintf(path, strlen(Buffer) +  1, "%s", &Buffer[i+1]);
+                    fclose(fp);
+                    if (path[strlen(path)-1] == '\n')
+                    {
+                        path[strlen(path)-1] = '\0';
+                    }
+                    return 0;
+                }
+            }
+        }
+    }
+    fclose(fp);
+    return 0;
+}
+
+int SetEvmt(int argc, char *argv[])
+{
+    for (int i = 0; i < argc; i++)
+    {
+        std::string cmd = argv[i];
+        if (cmd[0] == '-')
+        {
+            SetToolsPath(argv[i] ,argv[i+1]);
+        }
+
+    }
+    printf("Now, the environment variable is :\n");
+    PrintEvmt();
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/SegmentBAM.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/SegmentBAM.cpp
@@ -1,0 +1,334 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//The BAM files has been split in accordance with the chromosome split, then modify the relative address.
+//If you need to customize, you should modify the [bamlist] and [falist] in the working directory.
+//Command:     ./SegmentBAM <-w WorkPath> <-n SplitNumber>
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "SegmentBAM.h"
+#include "Environment.h"
+
+using namespace std;
+
+void Modify(char *buffer, char *chrname, int chrname_len, long addresses_number)
+{
+    if (buffer[0] == '@') return;
+    int count = 0;
+    int flag = 0;
+    for (int i = 0; i < (int)strlen(buffer); i++)
+    {
+        if (buffer[i] == '\t')
+        {
+            count++;
+            if (count == 3 || count == 7) flag = 1;
+        }
+        if (flag == 1)
+        {
+            char *p = &buffer[i + 1];
+            char Front[FILE_LINE], Rear[FILE_LINE];
+            char Number_Old[CMD_NUM], Number_New[CMD_NUM];
+            long Num_Old = atol(p);
+            snprintf(Number_Old, sizeof(Number_Old), "%ld", Num_Old);
+            int Length_Old = (int)strlen(Number_Old);
+            //Modify the starting address.
+            long Num_New = Num_Old - addresses_number;
+            snprintf(Number_New, sizeof(Number_New), "%ld", Num_New);
+            snprintf(Front, (size_t)(i + 2), "%s", buffer);
+            snprintf(Rear, sizeof(Rear), "%s", &buffer[i + 1 + Length_Old]);
+            strncat(Front, Number_New, sizeof(Front) - strlen(Front));
+            strncat(Front, Rear, sizeof(Front) - strlen(Front));
+            snprintf(buffer, FILE_LINE, "%s", Front);
+            flag = 0;
+        }
+        if (count == 7)
+        {
+            return;
+        }
+    }
+}
+
+int Sam_Address_Modify(char *file_name, const char *ChrName, long address_count)
+{
+    FILE *fp_old, *fp_new;
+    if ((fp_old = fopen(file_name, "r")) == NULL)
+        exit(-1);
+    char TmpName[CMD_NUM];
+    snprintf(TmpName, sizeof(TmpName), "%s-%d", file_name, (int)getpid());
+    if ((fp_new = fopen(TmpName, "w")) == NULL)
+        exit(-1);
+    int l1 = (int)strlen(ChrName);
+    char str1[l1];
+    strncpy(str1, ChrName, sizeof(str1)-1);
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    getline(&Buffer, &Len, fp_old);
+    while (!feof(fp_old))
+    {
+        Modify(Buffer, str1, l1, address_count);
+        fputs(Buffer, fp_new);
+        getline(&Buffer, &Len, fp_old);
+    }
+    fclose(fp_old);
+    fclose(fp_new);
+    remove(file_name);
+    rename(TmpName, file_name);
+    return 0;
+}
+
+int SegmentBAM(int argc, char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    char PATH_SAMTOOLS[CMD_NUM];
+    GetToolsPath(PATH_SAMTOOLS, "-samtools");
+
+    vector<string> ChrName;
+    vector<string> SampleName;
+    //Command string.
+    char ShellCommand[CMD_NUM];
+
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    char PathWork[CMD_NUM];
+    int SplitNumber;
+    
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-n")
+        {
+            SplitNumber = atoi(argv[i + 1]);
+        }
+    }
+    
+    
+    //Import BAM list, if you need to customize the list, you should modify the [bamlist], fill in the need to split the BAM file
+    FILE *fp_bam;
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/bamlist", PathWork);
+    if ((fp_bam = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_bam);
+    while (!feof(fp_bam))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            SampleName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_bam);
+    }
+    fclose(fp_bam);
+
+    //Import FA list, if you need to customize the list, you should modify the [falist], fill in the need to split the FA file
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/falist", PathWork);
+    FILE *fp_fa;
+    if ((fp_fa = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_fa);
+    while (!feof(fp_fa))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            ChrName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_fa);
+    }
+    fclose(fp_fa);
+
+    int FileNumber[ChrName.size()];
+
+    //Settings allow parallel nesting.
+    omp_set_nested(1);
+
+    //Parallel Computing
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); ++i)
+    {
+#pragma omp parallel for
+        for (int n = 0; n < (int)SampleName.size(); ++n)
+        {
+            char SortCommand[CMD_NUM];
+            FILE *fp_sort;
+            snprintf(SortCommand, sizeof(SortCommand), "%s/sample/%s/%s_%s.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            if ((fp_sort = fopen(SortCommand, "r")) == NULL) continue;
+            fclose(fp_sort);
+
+            //Sort and index.
+            snprintf(SortCommand, sizeof(SortCommand), "mkdir -p %s/sample/%s/%s_%s_TemporarySort", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            system(SortCommand);
+
+            snprintf(SortCommand, sizeof(SortCommand), "%s sort -T %s/sample/%s/%s_%s_TemporarySort %s/sample/%s/%s_%s.bam > %s/sample/%s/%s_%s_sorted.bam ", PATH_SAMTOOLS, PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            system(SortCommand);
+
+            snprintf(SortCommand, sizeof(SortCommand), "%s index %s/sample/%s/%s_%s_sorted.bam ", PATH_SAMTOOLS, PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            system(SortCommand);
+
+            snprintf(SortCommand, sizeof(SortCommand), "rm -rf %s/sample/%s/%s_%s_TemporarySort", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            system(SortCommand);
+        }
+    }
+
+    printf("Sort is end.\n");
+
+    long ReadCount[ChrName.size()][2 * SplitNumber];
+
+    //Split BAM according to each chromosome.
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); ++i)
+    {
+        char TransCommand[CMD_NUM];
+        char *TransBuffer = NULL;
+        size_t TransLen = FILE_LINE;
+
+        ReadCount[i][0] = 0;
+
+        snprintf(TransCommand, sizeof(TransCommand), "touch %s_tmp", ChrName[i].c_str());
+        system(TransCommand);
+
+        //Gets the length of each line in the fa file.
+        snprintf(TransCommand, sizeof(TransCommand), "wc -L %s/fa/%s.fa > %s_tmp", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+        system(TransCommand);
+        snprintf(TransCommand, sizeof(TransCommand), "%s_tmp", ChrName[i].c_str());
+        FILE *fp_sp;
+        if ((fp_sp = fopen(TransCommand, "r")) == NULL)
+            exit(-1);
+        getline(&TransBuffer, &TransLen, fp_sp);
+        int Maxlen_PreLine = atoi(TransBuffer);
+        fclose(fp_sp);
+
+        //Count the current number of files
+        snprintf(TransCommand, sizeof(TransCommand), "ls -l %s/fa/%s |grep \"^-\"|wc -l > %s_tmp ", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+        system(TransCommand);
+        snprintf(TransCommand, sizeof(TransCommand), "%s_tmp", ChrName[i].c_str());
+        if ((fp_sp = fopen(TransCommand, "r")) == NULL)
+            exit(-1);
+        getline(&TransBuffer, &TransLen, fp_sp);
+        //The number of files after bisection.
+        FileNumber[i] = atoi(TransBuffer);
+        fclose(fp_sp);
+
+        //Statistics read number.
+        for (int j = 0; j < FileNumber[i]; j++)
+        {
+            //Read the number of rows of the current FA file.
+            snprintf(TransCommand, sizeof(TransCommand), "wc -l %s/fa/%s/%s_%d.fa > %s_tmp", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), j, ChrName[i].c_str());
+            system(TransCommand);
+            snprintf(TransCommand, sizeof(TransCommand), "%s_tmp", ChrName[i].c_str());
+            if ((fp_sp = fopen(TransCommand, "r")) == NULL)
+                exit(-1);
+            getline(&TransBuffer, &TransLen, fp_sp);
+            fclose(fp_sp);
+
+            //Record the number of all reads so far.
+            ReadCount[i][j + 1] = ReadCount[i][j] + (atol(TransBuffer) - 1)*Maxlen_PreLine;
+        }
+        snprintf(TransCommand, sizeof(TransCommand), "%s_tmp", ChrName[i].c_str());
+        remove(TransCommand);
+        //Extract and modify BAM
+#pragma omp parallel for
+        for (int n = 0; n < (int)SampleName.size(); ++n)
+        {
+            char ModCommand[CMD_NUM];
+            FILE *fp_trans;
+            //If the chromosome is not present in the sample, it is skipped.
+            snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            if ((fp_trans = fopen(ModCommand, "r")) == NULL) continue;
+            fclose(fp_trans);
+
+            //Already exists before the chromosome processing data is deleted from the original data to prepare to write new data.
+            snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            DIR * bam_dir;
+            bam_dir = opendir(ModCommand);
+            if (bam_dir != NULL)
+            {
+                closedir(bam_dir);
+                snprintf(ModCommand, sizeof(ModCommand), "rm -rf %s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                system(ModCommand);
+            }
+
+            snprintf(ModCommand, sizeof(ModCommand), "mkdir -p %s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            system(ModCommand);
+            //printf("BAM file to extract...\n");
+
+            //Extract and modify BAM.
+            for (int k = 0; k < FileNumber[i]; k++)
+            {
+                // Extract read in the corresponding interval.
+                snprintf(ModCommand, sizeof(ModCommand),
+                         "%s view -bh %s/sample/%s/%s_%s_sorted.bam %s:%ld-%ld > %s/sample/%s/%s_%s/%s_%s_%d.bam", PATH_SAMTOOLS,
+                        PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), ChrName[i].c_str(),
+                        ReadCount[i][k] + 1, ReadCount[i][k + 1], PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k);
+                system(ModCommand);
+
+                //The split BAM file into SAM format.
+                snprintf(ModCommand, sizeof(ModCommand), "%s view -h %s/sample/%s/%s_%s/%s_%s_%d.bam > %s/sample/%s/%s_%s/%s_%s_%d.sam", PATH_SAMTOOLS, PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k, PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k);
+                system(ModCommand);
+                snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s/%s_%s_%d.bam", PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k);
+                remove(ModCommand);
+
+                //Sam address modified.
+                if (k > 0)
+                {
+                    snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s/%s_%s_%d.sam", PathWork, SampleName[n].c_str(),
+                            SampleName[n].c_str(), ChrName[i].c_str(),
+                            SampleName[n].c_str(), ChrName[i].c_str(), k);
+                    Sam_Address_Modify(ModCommand, ChrName[i].c_str(), ReadCount[i][k]);
+                }
+
+                //Change the modified sam file back to bam format.
+                snprintf(ModCommand, sizeof(ModCommand), "%s view -b %s/sample/%s/%s_%s/%s_%s_%d.sam > %s/sample/%s/%s_%s/%s_%s_%d.bam", PATH_SAMTOOLS, PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k, PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k);
+                system(ModCommand);
+                snprintf(ModCommand, sizeof(ModCommand), "%s/sample//%s/%s_%s/%s_%s_%d.sam", PathWork, SampleName[n].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(),
+                        SampleName[n].c_str(), ChrName[i].c_str(), k);
+                remove(ModCommand);
+            }
+            snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s_sorted.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            remove(ModCommand);
+            snprintf(ModCommand, sizeof(ModCommand), "%s/sample/%s/%s_%s_sorted.bam.bai", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+            remove(ModCommand);
+        }
+    }
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/SegmentFA.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/SegmentFA.cpp
@@ -1,0 +1,199 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Each chromosome FA file is divided into small portions according to the split number.
+//			all_Chr01.fa -----> all_Chr01_1.fa all_Chr01_2.fa all_Chr01_3.fa ……………….all_Chr01_N.fa
+//
+//Command:     ./SegmentFA <-w WorkPath> <-n SplitNumber> [-lm Size]
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "SegmentFA.h"
+
+using namespace std;
+
+int SegmentFA(int argc,char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    vector<string> ChrName;
+    FILE *fp_Tmp;
+    //Command string
+    char ShellCommand[CMD_NUM];
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    //Create a shell command to call the result log file
+    system("touch tmp");
+
+    long Limit = 0;
+    int SplitNumber;
+    char PathWork[CMD_NUM];
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-n")
+        {
+            SplitNumber = atoi(argv[i + 1]);
+        }
+        if (cmd == "-lm")
+        {
+            Limit = atol(argv[i + 1]);
+        }
+    }
+
+    FILE *fp_FA;
+    if(Limit == 0)
+    {
+        //Import FA list. If you need to customize the list, you should modify [falist], fill in the need to split the fa files.
+        snprintf(ShellCommand, sizeof(ShellCommand), "%s/falist", PathWork);
+        if ((fp_FA = fopen(ShellCommand, "r")) == NULL)
+            exit(-1);
+        getline(&Buffer, &Len, fp_FA);
+        while (!feof(fp_FA))
+        {
+            if (strlen(Buffer) != 0)
+            {
+                for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+                {
+                    if (Buffer[i] == '.')
+                    {
+                        Buffer[i] = '\0';
+                        break;
+                    }
+                }
+                ChrName.push_back(Buffer);
+            }
+            getline(&Buffer, &Len, fp_FA);
+        }
+        fclose(fp_FA);
+    }
+    else
+    {
+        snprintf(ShellCommand, sizeof(ShellCommand), "%s/falist", PathWork);
+        if ((fp_FA = fopen(ShellCommand, "w")) == NULL)
+            exit(-1);
+        DIR * dir;
+        struct dirent * ptr;
+        char FAFile[CMD_NUM];
+        snprintf(FAFile, sizeof(FAFile), "%s/fa",PathWork);
+        dir = opendir(FAFile);
+        while((ptr = readdir(dir)) != NULL)
+        {
+            if (ptr->d_type == 4) continue;
+            strncpy(FAFile, ptr->d_name, sizeof(FAFile)-1);
+            string Suffix;
+            for (int i = (int)strlen(FAFile) - 1; i > 0; i--)
+            {
+                if (FAFile[i] == '.')
+                {
+                    Suffix = FAFile + i + 1;
+                }
+            }
+            if (Suffix != "fa") continue;
+            //Call the command to query the FA file size.
+            snprintf(ShellCommand, sizeof(ShellCommand), "du -h --block-size=M %s/fa/%s > tmp", PathWork, ptr->d_name);
+            system(ShellCommand);
+            if ((fp_Tmp = fopen("tmp", "r")) == NULL)
+                exit(-1);
+            getline(&Buffer, &Len, fp_Tmp);
+            fclose(fp_Tmp);
+            long FASize = atol(Buffer);
+            if (FASize < Limit) continue;
+            strncpy(FAFile, ptr->d_name, sizeof(FAFile)-1);
+            fputs(FAFile, fp_FA);
+            fputs("\n", fp_FA);
+            for (int i = (int)strlen(FAFile) - 1; i > 0; i--)
+            {
+                if (FAFile[i] == '.')
+                {
+                    FAFile[i] = '\0';
+                    break;
+                }
+            }
+            ChrName.push_back(FAFile);
+        }
+        closedir(dir);
+        fclose(fp_FA);
+    }
+
+    int FileNumber[ChrName.size()];
+
+    //Each chromosome is divided
+    for (int i = 0; i < (int)ChrName.size(); ++i)
+    {
+        snprintf(ShellCommand, sizeof(ShellCommand), "du -h --block-size=M %s/fa/%s.fa > tmp ", PathWork, ChrName[i].c_str());
+        system(ShellCommand);
+        if ((fp_Tmp = fopen("tmp", "r")) == NULL)
+            exit(-1);
+        getline(&Buffer, &Len, fp_Tmp);
+        fclose(fp_Tmp);
+        long FASize = atol(Buffer);
+        //Calculate the size of each post split.
+        long fa_split_piece_size = FASize / SplitNumber;
+
+        //Already exists before the chromosome processing data is deleted from the original data to prepare to write new data.
+        snprintf(ShellCommand, sizeof(ShellCommand), "%s/fa/%s", PathWork, ChrName[i].c_str());
+        DIR * fa_dir;
+        fa_dir = opendir(ShellCommand);
+        if (fa_dir != NULL)
+        {
+            closedir(fa_dir);
+            snprintf(ShellCommand, sizeof(ShellCommand), "rm -rf %s/fa/%s", PathWork, ChrName[i].c_str());
+            system(ShellCommand);
+        }
+        snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/fa/%s", PathWork, ChrName[i].c_str());
+        system(ShellCommand);
+
+        printf("FA files cutting...\n");
+        snprintf(ShellCommand, sizeof(ShellCommand), "split -C %ldM %s/fa/%s.fa %s_", fa_split_piece_size, PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+        system(ShellCommand);
+        snprintf(ShellCommand, sizeof(ShellCommand), "mv %s_* %s/fa/%s", ChrName[i].c_str(), PathWork, ChrName[i].c_str());
+        system(ShellCommand);
+        printf("FA files cutting is done\n");
+
+        //Count the current number of files
+        snprintf(ShellCommand, sizeof(ShellCommand), "ls -l %s/fa/%s |grep \"^-\"|wc -l > tmp ", PathWork, ChrName[i].c_str());
+        system(ShellCommand);
+        if ((fp_Tmp = fopen("tmp", "r")) == NULL)
+            exit(-1);
+        getline(&Buffer, &Len, fp_Tmp);
+        //The number of files after bisection
+        FileNumber[i] = atoi(Buffer);
+        fclose(fp_Tmp);
+        printf("FA files renaming...\n");
+        for (int n = 0; n < FileNumber[i]; n++)
+        {
+            char j = (char)('a' + n / 26);
+            char k = (char)('a' + n % 26);
+            snprintf(ShellCommand, sizeof(ShellCommand), "mv %s/fa/%s/%s_%c%c %s/fa/%s/%s_%d.fa", PathWork, ChrName[i].c_str(),
+                    ChrName[i].c_str(), j, k, PathWork, ChrName[i].c_str(),
+                    ChrName[i].c_str(), n);
+            system(ShellCommand);
+
+            //Add the header to all the FA files after the first file
+            if (n > 0)
+            {
+                snprintf(ShellCommand, sizeof(ShellCommand), "sed -i \"1i>%s\" %s/fa/%s/%s_%d.fa", ChrName[i].c_str(), PathWork,
+                        ChrName[i].c_str(), ChrName[i].c_str(), n);
+                system(ShellCommand);
+            }
+        }
+        printf("FA files rename is done.\n");
+    }
+    remove("tmp");
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/SmallFA.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/SmallFA.cpp
@@ -1,0 +1,220 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Calculate the small chromosome FA files.
+//Command: ./SmallFA <-w WorkPath>
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "SmallFA.h"
+#include "Environment.h"
+
+using namespace std;
+
+int SmallFA(int argc, char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    char PATH_SAMTOOLS[CMD_NUM];
+    GetToolsPath(PATH_SAMTOOLS, "-samtools");
+    char PATH_BCFTOOLS[CMD_NUM];
+    GetToolsPath(PATH_BCFTOOLS, "-bcftools");
+    char PATH_GATK[CMD_NUM];
+    GetToolsPath(PATH_GATK, "-gatk");
+    char PATH_FREEBAYES[CMD_NUM];
+    GetToolsPath(PATH_FREEBAYES, "-freebayes");
+
+    vector<string> ChrName;
+    vector<string> SampleName;
+    //Command string.
+    char ShellCommand[CMD_NUM];
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    char PathWork[CMD_NUM];
+    char Queue[CMD_NUM] = "normal";
+    char Span[CMD_NUM] = "20";
+    string Tool = "samtools";
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-q")
+        {
+            snprintf(Queue, sizeof(Queue), "%s", argv[i + 1]);
+        }
+        if (cmd == "-Span")
+        {
+            snprintf(Span, sizeof(Span), "%s", argv[i + 1]);
+        }
+        if (cmd == "-T")
+        {
+            Tool = argv[i + 1];
+        }
+    }
+    snprintf(ShellCommand, sizeof(ShellCommand), "ls -al %s/fa | grep '^-' | grep '.fa$' | awk '{print $9}' > %s/smalllist_tmp", PathWork, PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "sort %s/smalllist_tmp %s/falist %s/falist | uniq -u > %s/smalllist" , PathWork, PathWork, PathWork, PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "rm %s/smalllist_tmp" , PathWork);
+    system(ShellCommand);
+
+    //Import BAM list, if you need to customize the list, you should modify the [bamlist], fill in the need to split the BAM file
+    FILE *fp_bam;
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/bamlist", PathWork);
+    if ((fp_bam = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_bam);
+    while (!feof(fp_bam))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            SampleName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_bam);
+    }
+    fclose(fp_bam);
+
+    //Import FA list, if you need to customize the list, you should modify the [falist], fill in the need to split the FA file
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/smalllist", PathWork);
+    FILE *fp_fa;
+    if ((fp_fa = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_fa);
+    while (!feof(fp_fa))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            ChrName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_fa);
+    }
+    fclose(fp_fa);
+
+    //Create the relevant directory.
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/out", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/out/smallFA", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/err", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/err/smallFA", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/sub_script", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/sub_script/smallFA", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/vcf", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/vcf/Final_Result", PathWork);
+    system(ShellCommand);
+
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); i++)
+    {
+        char Command[CMD_NUM];
+        //Write the commit script.
+        FILE *fp_sh;
+        snprintf(Command, sizeof(Command), "%s/sub_script/smallFA/%s_%s.sh", PathWork, ChrName[i].c_str(), Tool.c_str());
+        if ((fp_sh = fopen(Command, "w")) == NULL)
+            exit(-1);
+        snprintf(Command, sizeof(Command), "#BSUB -q %s\n", Queue);
+        fputs(Command, fp_sh);
+        snprintf(Command, sizeof(Command), "#BSUB -J %s_%s\n", ChrName[i].c_str(), Tool.c_str());
+        fputs(Command, fp_sh);
+        snprintf(Command, sizeof(Command), "#BSUB -o %s/out/smallFA/%s_%s.out\n", PathWork, ChrName[i].c_str(), Tool.c_str());
+        fputs(Command, fp_sh);
+        snprintf(Command, sizeof(Command), "#BSUB -e %s/err/smallFA/%s_%s.err\n", PathWork, ChrName[i].c_str(), Tool.c_str());
+        fputs(Command, fp_sh);
+        snprintf(Command, sizeof(Command), "#BSUB -n 1\n");
+        fputs(Command, fp_sh);
+        snprintf(Command, sizeof(Command), "#BSUB -R \"span[ptile=%s]\"\n", Span);
+        fputs(Command, fp_sh);
+
+        if (Tool == "samtools")
+        {
+            snprintf(Command, sizeof(Command), "%s mpileup -u -t DP,AD,ADF -f ", PATH_SAMTOOLS);
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "%s/fa/%s.fa ", PathWork, ChrName[i].c_str());
+            fputs(Command, fp_sh);
+            //Write a number of sample small copies.
+            for (int n = 0; n < (int)SampleName.size(); n++)
+            {
+                snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                system(Command);
+
+                snprintf(Command, sizeof(Command), "%s/sample/%s/%s_%s.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                fputs(Command, fp_sh);
+            }
+            snprintf(Command, sizeof(Command), "| %s call -vmO v -o %s/vcf/Final_Result/%s.var.flt.vcf ", PATH_BCFTOOLS, PathWork, ChrName[i].c_str());
+            fputs(Command, fp_sh);
+        }
+        else if (Tool == "gatk")
+        {
+            snprintf(Command, sizeof(Command), "java -jar %s -T HaplotypeCaller ", PATH_GATK);
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "-R %s/fa/%s/%s.fa -nct 1 ", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+            fputs(Command, fp_sh);
+            for (int n = 0; n < (int)SampleName.size(); n++)
+            {
+                snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s/%s_%s.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                system(Command);
+
+                snprintf(Command, sizeof(Command), "-I %s/sample/%s/%s_%s/%s_%s.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                fputs(Command, fp_sh);
+            }
+            snprintf(Command, sizeof(Command), "-o %s/vcf/Final_Result/%s.vcf ", PathWork, ChrName[i].c_str());
+            fputs(Command, fp_sh);
+        }
+        else if (Tool == "freebayes")
+        {
+            snprintf(Command, sizeof(Command), "/usr/bin/time -f \"%E\" %s --strict-vcf ", PATH_FREEBAYES);
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "-f %s/fa/%s/%s.fa ", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+            fputs(Command, fp_sh);
+            for (int n = 0; n < (int)SampleName.size(); n++)
+            {
+                snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s/%s_%s.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                system(Command);
+
+                snprintf(Command, sizeof(Command), "-b %s/sample/%s/%s_%s/%s_%s.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                fputs(Command, fp_sh);
+            }
+            snprintf(Command, sizeof(Command), "-v %s/vcf/Final_Result/%s.vcf ", PathWork, ChrName[i].c_str());
+            fputs(Command, fp_sh);
+        }
+        fclose(fp_sh);
+        // Submit.
+        snprintf(Command, sizeof(Command), "bsub < %s/sub_script/smallFA/%s_%s.sh", PathWork, ChrName[i].c_str(), Tool.c_str());
+        system(Command);
+    }
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/SplitBAM.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/SplitBAM.cpp
@@ -1,0 +1,131 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//The source ratio of the sample bam file is divided into small portions according to the included chromosome.
+//		S001.merge.bam -------- S001_Chr01.bam S001_Chr02.bam S001_Chr03.bam ...... S001_ChrN.bam
+//
+//Command:    ./SplitBAM <-w WorkPath> <-bam BAMPath> [-I]
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "SplitBAM.h"
+#include "Environment.h"
+
+using namespace std;
+
+int SplitBAM(int argc,char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    vector<string> SampleName;
+
+    char PATH_BAMUTIL[CMD_NUM];
+    GetToolsPath(PATH_BAMUTIL, "-bamUtil");
+
+    char ShellCommand[CMD_NUM];
+    char PathWork[CMD_NUM];
+    char PathBAM[CMD_NUM];
+    bool ImportBAM = false;
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-bam")
+        {
+            snprintf(PathBAM, sizeof(PathBAM), "%s", argv[i + 1]);
+        }
+        if (cmd == "-I")
+        {
+            ImportBAM = true;
+        }
+    }
+
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/sample", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "touch %s/bamlist", PathWork);
+    system(ShellCommand);
+
+    FILE *fp_bam;
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    //Import BAM list. If you need to customize the list, you should modify the [bamlist], fill in the need to split the BAM file
+    if (ImportBAM == false)
+    {
+        char BAMFile[CMD_NUM];
+        snprintf(ShellCommand, sizeof(ShellCommand), "%s/bamlist", PathWork);
+        if ((fp_bam = fopen(ShellCommand, "w")) == NULL)
+            exit(-1);
+        DIR *dir;
+        struct dirent *ptr;
+        snprintf(BAMFile, sizeof(ShellCommand), "%s", PathBAM);
+        dir = opendir(BAMFile);
+        while ((ptr = readdir(dir)) != NULL)
+        {
+            if (ptr->d_type == 4) continue;
+            strncpy(BAMFile, ptr->d_name, sizeof(BAMFile)-1);
+            string Suffix;
+            for (int i = (int) strlen(BAMFile) - 1; i > 0; i--)
+            {
+                if (BAMFile[i] == '.')
+                {
+                    Suffix = BAMFile + i + 1;
+                    break;
+                }
+            }
+            if (Suffix != "bam") continue;
+            fputs(BAMFile, fp_bam);
+            fputs("\n", fp_bam);
+        }
+        closedir(dir);
+        fclose(fp_bam);
+    }
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/bamlist", PathWork);
+    if ((fp_bam = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_bam);
+    while (!feof(fp_bam))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            SampleName.push_back(Buffer);
+            snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/sample/%s", PathWork, Buffer);
+            system(ShellCommand);
+        }
+        getline(&Buffer, &Len, fp_bam);
+    }
+    fclose(fp_bam);
+
+    printf("The sample was split according to the chromosome...\n");
+
+//Parallel Computing
+#pragma omp parallel for
+    for (int k = 0; k < (int)SampleName.size(); ++k)//The sample is split by chromosome.
+    {
+        char Command[CMD_NUM];
+        snprintf(Command, sizeof(ShellCommand), "%s splitChromosome --in %s/%s.bam --out %s/sample/%s/%s_ --bamout", PATH_BAMUTIL, PathBAM, SampleName[k].c_str(),PathWork,SampleName[k].c_str(),SampleName[k].c_str());
+        system(Command);
+    }
+    printf("The sample was split by chromosome resolution.\n");
+
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/SplitFA.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/SplitFA.cpp
@@ -1,0 +1,102 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//The source gene sequence fa is split into small portions according to the included chromosomes
+//		all.fa ------> all_Chr01.fa all_Chr02.fa ………….all_ChrN.fa
+//
+//Command:  ./SplitFA	<-w WorkPath> <-fa FAPath>
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "SplitFA.h"
+#include "Environment.h"
+
+using namespace std;
+
+//The FA file is divided into chromosomes and obtained after cutting the chromosome name.
+void Fa_Chr(char *workpath,char *fa_path)
+{
+    FILE *fp;
+    if((fp = fopen(fa_path, "r")) == NULL)
+        exit(-1);
+    char *Line = NULL;
+    size_t Len = FILE_LINE;
+    char FileName[CMD_NUM];
+    char ShellCommand[CMD_NUM];
+    //Create the FA directory.
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/fa", workpath);
+    system(ShellCommand);
+    getline(&Line, &Len, fp);
+    //Extract the sequence of each chromosome
+    while (!feof(fp))
+    {
+        strncpy(FileName,Line + 1 ,sizeof(FileName) - 4);
+        for (int i = 0; i < (int)strlen(FileName); i++)
+        {
+            if(FileName[i] == ' ' || FileName[i] == '\t' || FileName[i] == '\n')
+            {
+                FileName[i] = '\0';
+                break;
+            }
+        }
+        strncat(FileName, ".fa", sizeof(FileName) - strlen(FileName));
+        snprintf(ShellCommand, sizeof(ShellCommand), "touch %s", FileName);
+        system(ShellCommand);
+
+        FILE *fp_tmp;
+        if((fp_tmp = fopen(FileName, "w")) == NULL)
+            exit(-1);
+
+        fputs(Line, fp_tmp);
+        getline(&Line, &Len, fp);
+        while (strstr(Line, ">") == NULL && feof(fp) == 0)
+        {
+            fputs(Line, fp_tmp);
+            getline(&Line, &Len, fp);
+        }
+        fclose(fp_tmp);
+        snprintf(ShellCommand, sizeof(ShellCommand), "mv %s %s/fa/", FileName, workpath);
+        system(ShellCommand);
+    }
+    fclose(fp);
+}
+
+int SplitFA(int argc,char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    char ShellCommand[CMD_NUM];
+
+    char PathWork[CMD_NUM];
+    char PathFA[CMD_NUM];
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-fa")
+        {
+            snprintf(PathFA, sizeof(PathFA), "%s", argv[i + 1]);
+        }
+    }
+
+    //Generates an empty [falist] for import.
+    snprintf(ShellCommand, sizeof(ShellCommand), "touch %s/falist", PathWork);
+    system(ShellCommand);
+
+    //Cut the FA file.
+    Fa_Chr(PathWork, PathFA);
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+
+    return 0;
+}
+

--- a/PVCTools_alpha_v2.5/src/childnode/StitchVCF.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/StitchVCF.cpp
@@ -1,0 +1,232 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+//////////////////////////////////////////////////////
+//Stitching the calculated VCF file.
+//Command:	./StitchVCF	<-w WorkPath>	<-n SplitNumber>
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "StitchVCF.h"
+#include "Environment.h"
+
+using namespace std;
+
+void VCF_Modify(char *buffer, const char *chrname, int chrname_len, long addresses_number)
+{
+    int count = 0;
+    for (int i = 0; i < (int)strlen(buffer); i++)
+    {
+        if (buffer[i] == '\t')
+        {
+            count++;
+        }
+        if (count == 1)
+        {
+            char *p = &buffer[i + 1];
+            char Front[FILE_LINE], Rear[FILE_LINE];
+            char Number_Old[CMD_NUM], Number_New[CMD_NUM];
+            long Num_Old = atol(p);
+            snprintf(Number_Old, sizeof(Number_Old), "%ld", Num_Old);
+            int Length_Old = (int)strlen(Number_Old);
+            //Modify the starting address.
+            long Num_New = Num_Old + addresses_number;
+            snprintf(Number_New, sizeof(Number_New), "%ld", Num_New);
+            snprintf(Front, (size_t)(i + 2), "%s", buffer);
+            snprintf(Rear, sizeof(Rear), "%s", &buffer[i + 1 + Length_Old]);
+            strncat(Front, Number_New, sizeof(Front) - strlen(Front));
+            strncat(Front, Rear, sizeof(Front) - strlen(Front));
+            //memset(buffer, 0, FILE_LINE);
+            snprintf(buffer, FILE_LINE, "%s", Front);
+            //memset(Front, 0, FILE_LINE);
+            //memset(Rear, 0, FILE_LINE);
+            return;
+        }
+    }
+}
+
+int VCF_Link(char *tarfile, char *formfile, const char *ChrName, long add_count)
+{
+    FILE *fp_tag, *fp_frm;
+    if((fp_tag=fopen(tarfile,"a+"))==NULL)
+        exit(-1);
+    if((fp_frm=fopen(formfile,"r"))==NULL)
+        exit(-1);
+
+    fseek(fp_tag,0,SEEK_END);
+
+    //Skip the source file to the beginning of the "##" section.
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    while (1)
+    {
+        getline(&Buffer, &Len,fp_frm);
+        if(feof(fp_frm))
+        {
+            printf("There is no need to stitch the content!");
+            return 0;
+        }
+        if(Buffer[0] != '#') break;
+    }
+
+    //Write the cache, modify the address, write the stitching file.
+    while (1)
+    {
+        //Restore the address in VCF.
+        VCF_Modify(Buffer,ChrName,(int)strlen(ChrName),add_count);
+        fputs(Buffer,fp_tag);
+        getline(&Buffer, &Len,fp_frm);
+        if(feof(fp_frm)) break;
+    }
+
+    fclose(fp_frm);
+    fclose(fp_tag);
+    return 0;
+
+}
+
+int StitchVCF(int argc,char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    vector<string> ChrName;
+    //Command string.
+    char ShellCommand[CMD_NUM];
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    
+    char PathWork[CMD_NUM];
+    int SplitNumber;
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-n")
+        {
+            SplitNumber = atoi(argv[i + 1]);
+        }
+    }
+
+    //Import FA list, if you need to customize the list, you should modify the [falist], fill in the need to split the FA file.
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/falist", PathWork);
+    FILE *fp_fa;
+    if ((fp_fa = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len,fp_fa);
+    while (!feof(fp_fa))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            ChrName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len,fp_fa);
+    }
+    fclose(fp_fa);
+
+//    omp_set_nested(1);
+
+    int FileNumber[ChrName.size()];
+    long ReadCount[ChrName.size()][2 * SplitNumber];
+
+    printf("The VCF results are in the statistics...\n");
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); ++i)
+    {
+        char Command[CMD_NUM];
+        char *VCFBuffer = NULL;
+        size_t VCFLen = FILE_LINE;
+
+        ReadCount[i][0] = 0;
+
+        snprintf(Command, sizeof(Command), "touch %s_tmp", ChrName[i].c_str());
+        system(Command);
+        //Count the current number of FA files.
+        snprintf(Command, sizeof(Command), "ls -l %s/fa/%s |grep \"^-\"|wc -l > %s_tmp", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+        system(Command);
+        snprintf(Command, sizeof(Command), "%s_tmp", ChrName[i].c_str());
+        FILE *fp_chr;
+        if ((fp_chr = fopen(Command, "r")) == NULL)
+            exit(-1);
+        getline(&VCFBuffer, &VCFLen, fp_chr);
+        FileNumber[i] = atoi(VCFBuffer) / 2;
+        fclose(fp_chr);
+
+        //Get the length of each line in the FA files.
+        snprintf(Command, sizeof(Command), "wc -L %s/fa/%s.fa > %s_tmp", PathWork, ChrName[i].c_str(),
+                ChrName[i].c_str());
+        system(Command);
+        snprintf(Command, sizeof(Command), "%s_tmp", ChrName[i].c_str());
+        if ((fp_chr = fopen(Command, "r")) == NULL)
+            exit(-1);
+        getline(&VCFBuffer, &VCFLen, fp_chr);
+        int Maxlen_PreLine = atoi(VCFBuffer);
+        fclose(fp_chr);
+
+        for (int j = 0; j < FileNumber[i]; j++)
+        {
+            //Read the current FA file number of rows.
+            snprintf(Command, sizeof(Command), "wc -l %s/fa/%s/%s_%d.fa > %s_tmp", PathWork, ChrName[i].c_str(),
+                    ChrName[i].c_str(), j, ChrName[i].c_str());
+            system(Command);
+            snprintf(Command, sizeof(Command), "%s_tmp", ChrName[i].c_str());
+            if ((fp_chr = fopen(Command, "r")) == NULL)
+                exit(-1);
+            getline(&VCFBuffer, &VCFLen, fp_chr);
+            fclose(fp_chr);
+
+            //Record the number of all reads so far.
+            ReadCount[i][j + 1] = ReadCount[i][j] + (atol(VCFBuffer) - 1) * Maxlen_PreLine;
+
+        }
+        snprintf(Command, sizeof(Command), "%s_tmp", ChrName[i].c_str());
+        remove(Command);
+    }
+    printf("VCF results are completed.\n");
+
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/vcf/Final_Result", PathWork);
+    system(ShellCommand);
+
+    printf("VCF results stitching ...\n");
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); i++)
+    {
+        char Command[CMD_NUM];
+
+        //Copy a copy of the first VCF file.
+        snprintf(Command, sizeof(Command), "cp -f %s/vcf/%s/%s_0.var.flt.vcf %s/vcf/Final_Result/%s.var.flt.vcf", PathWork,
+                ChrName[i].c_str(), ChrName[i].c_str(), PathWork,
+                ChrName[i].c_str());
+        system(Command);
+
+        char VCF_File[CMD_NUM];
+        snprintf(VCF_File, sizeof(VCF_File), "%s/vcf/Final_Result/%s.var.flt.vcf", PathWork, ChrName[i].c_str());
+
+        for (int n = 1; n < FileNumber[i]; n++)
+        {
+            snprintf(Command, sizeof(Command), "%s/vcf/%s/%s_%d.var.flt.vcf", PathWork, ChrName[i].c_str(),ChrName[i].c_str(),n);
+            VCF_Link(VCF_File, Command, ChrName[i].c_str(), ReadCount[i][n]);
+        }
+    }
+    printf("VCF results stitching done.\n");
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/Submit.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/Submit.cpp
@@ -1,0 +1,255 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//Submit and calculate VCF results.
+//If you need to customize, you should modify the [bamlist] and [falist] in the working directory.
+//Command: ./Submit <-w WorkPath>
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "Submit.h"
+#include "Environment.h"
+
+using namespace std;
+
+int Submit(int argc, char *argv[])
+{
+    long StartTime = time((time_t*)NULL);
+    printf("start time = %ld\n", StartTime);
+
+    char PATH_SAMTOOLS[CMD_NUM];
+    GetToolsPath(PATH_SAMTOOLS, "-samtools");
+    char PATH_BCFTOOLS[CMD_NUM];
+    GetToolsPath(PATH_BCFTOOLS, "-bcftools");
+    char PATH_GATK[CMD_NUM];
+    GetToolsPath(PATH_GATK, "-gatk");
+    char PATH_FREEBAYES[CMD_NUM];
+    GetToolsPath(PATH_FREEBAYES, "-freebayes");
+
+    vector<string> ChrName;
+    vector<string> SampleName;
+    //Command string.
+    char ShellCommand[CMD_NUM];
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+
+    char PathWork[CMD_NUM];
+    char Queue[CMD_NUM] = "fatnode";
+    char Span[CMD_NUM] = "20";
+    string Tool = "samtools";
+
+    for (int i = 0; i < argc; i++)
+    {
+        string cmd = argv[i];
+        if (cmd == "-w")
+        {
+            snprintf(PathWork, sizeof(PathWork), "%s", argv[i + 1]);
+        }
+        if (cmd == "-q")
+        {
+            snprintf(Queue, sizeof(Queue), "%s", argv[i + 1]);
+        }
+        if (cmd == "-Span")
+        {
+            snprintf(Span, sizeof(Span), "%s", argv[i + 1]);
+        }
+        if (cmd == "-T")
+        {
+            Tool = argv[i + 1];
+        }
+    }
+
+    //Import BAM list, if you need to customize the list, you should modify the [bamlist], fill in the need to split the BAM file.
+    FILE *fp_bam;
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/bamlist", PathWork);
+    if ((fp_bam = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_bam);
+    while (!feof(fp_bam))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            SampleName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_bam);
+    }
+    fclose(fp_bam);
+
+    //Import FA list, if you need to customize the list, you should modify the [falist], fill in the need to split the FA file.
+    snprintf(ShellCommand, sizeof(ShellCommand), "%s/falist", PathWork);
+    FILE *fp_fa;
+    if ((fp_fa = fopen(ShellCommand, "r")) == NULL)
+        exit(-1);
+    getline(&Buffer, &Len, fp_fa);
+    while (!feof(fp_fa))
+    {
+        if (strlen(Buffer) != 0)
+        {
+            for (int i = (int)strlen(Buffer) - 1; i > 0; i--)
+            {
+                if (Buffer[i] == '.')
+                {
+                    Buffer[i] = '\0';
+                    break;
+                }
+            }
+            ChrName.push_back(Buffer);
+        }
+        getline(&Buffer, &Len, fp_fa);
+    }
+    fclose(fp_fa);
+
+    int FileNumber[ChrName.size()];
+
+
+    //Each chromosome is counted.
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); ++i)
+    {
+        char Command[CMD_NUM];
+        char *SubBuffer = NULL;
+        size_t SubLen = FILE_LINE;
+
+        snprintf(Command, sizeof(Command), "touch %s_tmp", ChrName[i].c_str());
+        system(Command);
+
+        FILE *fp_sp;
+        //Count the current number of files.
+        snprintf(Command, sizeof(Command), "ls -l %s/fa/%s |grep \"^-\"|wc -l > %s_tmp ", PathWork, ChrName[i].c_str(), ChrName[i].c_str());
+        system(Command);
+        snprintf(Command, sizeof(Command), "%s_tmp", ChrName[i].c_str());
+        if ((fp_sp = fopen(Command, "r")) == NULL)
+            exit(-1);
+        getline(&SubBuffer, &SubLen, fp_sp);
+        //The number of files after bisection.
+        FileNumber[i] = atoi(SubBuffer);
+
+        snprintf(Command, sizeof(Command), "rm -rf %s_tmp ", ChrName[i].c_str());
+        system(Command);
+
+    }
+
+    //Create the relevant directory.
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/out", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/err", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/sub_script", PathWork);
+    system(ShellCommand);
+    snprintf(ShellCommand, sizeof(ShellCommand), "mkdir -p %s/vcf", PathWork);
+    system(ShellCommand);
+
+#pragma omp parallel for
+    for (int i = 0; i < (int)ChrName.size(); i++)
+    {
+        char Command[CMD_NUM];
+        snprintf(Command, sizeof(Command), "mkdir -p %s/vcf/%s", PathWork, ChrName[i].c_str());
+        system(Command);
+        //Write the commit script.
+        for (int k = 0; k < FileNumber[i]; k++)
+        {
+            FILE *fp_sh;
+            snprintf(Command, sizeof(Command), "%s/sub_script/%s_%d_%s.sh", PathWork, ChrName[i].c_str(), k, Tool.c_str());
+            if ((fp_sh = fopen(Command, "w")) == NULL)
+                exit(-1);
+            snprintf(Command, sizeof(Command), "#BSUB -q %s\n", Queue);
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "#BSUB -J %s_%d_%s\n", ChrName[i].c_str(), k, Tool.c_str());
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "#BSUB -o %s/out/%s_%d_%s.out\n", PathWork, ChrName[i].c_str(), k, Tool.c_str());
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "#BSUB -e %s/err/%s_%d_%s.err\n", PathWork, ChrName[i].c_str(), k, Tool.c_str());
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "#BSUB -n 1\n");
+            fputs(Command, fp_sh);
+            snprintf(Command, sizeof(Command), "#BSUB -R \"span[ptile=%s]\"\n", Span);
+            fputs(Command, fp_sh);
+
+            if (Tool == "samtools")
+            {
+                snprintf(Command, sizeof(Command), "%s mpileup -u -t DP,AD,ADF -f ", PATH_SAMTOOLS);
+                fputs(Command, fp_sh);
+                snprintf(Command, sizeof(Command), "%s/fa/%s/%s_%d.fa ", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+                //Write a number of sample small copies.
+                for (int n = 0; n < (int)SampleName.size(); n++)
+                {
+                    snprintf(Command, sizeof(Command), "mkdir -p %s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s/%s_%s_%d.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(),k);
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "%s/sample/%s/%s_%s/%s_%s_%d.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), k);
+                    fputs(Command, fp_sh);
+                }
+                snprintf(Command, sizeof(Command), "| %s call -vmO v -o %s/vcf/%s/%s_%d.var.flt.vcf ", PATH_BCFTOOLS, PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+            }
+            else if (Tool == "gatk")
+            {
+                snprintf(Command, sizeof(Command), "java -jar %s -T HaplotypeCaller ", PATH_GATK);
+                fputs(Command, fp_sh);
+                snprintf(Command, sizeof(Command), "-R %s/fa/%s/%s_%d.fa -nct 1 ", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+                for (int n = 0; n < (int)SampleName.size(); n++)
+                {
+                    snprintf(Command, sizeof(Command), "mkdir -p %s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s/%s_%s_%d.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(),k);
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "-I %s/sample/%s/%s_%s/%s_%s_%d.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), k);
+                    fputs(Command, fp_sh);
+                }
+                snprintf(Command, sizeof(Command), "-o %s/vcf/%s/%s_%d.vcf ", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+            }
+            else if (Tool == "freebayes")
+            {
+                snprintf(Command, sizeof(Command), "/usr/bin/time -f \"%E\" %s --strict-vcf ", PATH_FREEBAYES);
+                fputs(Command, fp_sh);
+                snprintf(Command, sizeof(Command), "-f %s/fa/%s/%s_%d.fa ", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+                for (int n = 0; n < (int)SampleName.size(); n++)
+                {
+                    snprintf(Command, sizeof(Command), "mkdir -p %s/sample/%s/%s_%s", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str());
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "touch %s/sample/%s/%s_%s/%s_%s_%d.bam", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(),k);
+                    system(Command);
+
+                    snprintf(Command, sizeof(Command), "-b %s/sample/%s/%s_%s/%s_%s_%d.bam ", PathWork, SampleName[n].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), SampleName[n].c_str(), ChrName[i].c_str(), k);
+                    fputs(Command, fp_sh);
+                }
+                snprintf(Command, sizeof(Command), "-v %s/vcf/%s/%s_%d.vcf ", PathWork, ChrName[i].c_str(), ChrName[i].c_str(), k);
+                fputs(Command, fp_sh);
+            }
+
+            fclose(fp_sh);
+
+            // Submit.
+            snprintf(Command, sizeof(Command), "bsub < %s/sub_script/%s_%d_%s.sh", PathWork, ChrName[i].c_str(), k, Tool.c_str());
+            system(Command);
+        }
+    }
+    printf("The VCF task has been submitted to each node.\n");
+    printf("Wait for the VCF task to complete the VCF statistics program after all the calculations have been completed.\n");
+
+    long FinishTime = time((time_t*)NULL);
+    printf("finish time = %ld\n", FinishTime);
+    long RunningTime = FinishTime - StartTime;
+    printf("running time = %ld\n", RunningTime);
+
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/childnode/main.cpp
+++ b/PVCTools_alpha_v2.5/src/childnode/main.cpp
@@ -1,0 +1,60 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+#include <iostream>
+#include "SegmentBAM.h"
+#include "SegmentFA.h"
+#include "SplitBAM.h"
+#include "SplitFA.h"
+#include "StitchVCF.h"
+#include "Submit.h"
+#include "SmallFA.h"
+
+int main(int argc, char *argv[])
+{
+    std::string cmd = argv[1];
+    if (cmd == "SplitFA" )
+    {
+        SplitFA(argc - 1, argv + 1);
+    }
+    else if (cmd == "SegmentFA")
+    {
+        SegmentFA(argc - 1, argv + 1);
+    }
+    else if (cmd == "SplitBAM")
+    {
+        SplitBAM(argc - 1, argv + 1);
+    }
+    else if (cmd == "SegmentBAM")
+    {
+        SegmentBAM(argc - 1, argv + 1);
+    }
+    else if (cmd == "Submit")
+    {
+        Submit(argc - 1, argv + 1);
+    }
+    else if (cmd == "StitchVCF")
+    {
+        StitchVCF(argc - 1, argv + 1);
+    }
+    else if (cmd == "SmallFA")
+    {
+        SmallFA(argc - 1, argv + 1);
+    }
+    else if (cmd == "GetVCF")
+    {
+        SplitFA(argc - 1, argv + 1);
+        SegmentFA(argc - 1, argv + 1);
+        SplitBAM(argc - 1, argv + 1);
+        SegmentBAM(argc - 1, argv + 1);
+        Submit(argc - 1, argv + 1);
+    }
+    else
+    {
+        std::cout << "Error: Error Parameters." << std::endl;
+        std::cout << "Parameters should be 'SplitFA' 'SegmentFA' 'SplitBAM' 'SegmentBAM' 'Submit' 'StitchVCF' or 'SmallFA'." << std::endl;
+        std::cout << std::endl;
+    }
+
+    return true;
+}

--- a/PVCTools_alpha_v2.5/src/headnode/Environment.cpp
+++ b/PVCTools_alpha_v2.5/src/headnode/Environment.cpp
@@ -1,0 +1,125 @@
+//
+// Created by liujiajun on 2017/4/23.
+//
+
+#include "Environment.h"
+
+int PrintEvmt()
+{
+    FILE *fp;
+    if ((fp = fopen("config", "r")) == NULL)
+        exit(-1);
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp))
+    {
+        getline(&Buffer,&Len,fp);
+        std::cout << Buffer << std::endl;
+    }
+    fclose(fp);
+    printf("\n");
+    return 0;
+}
+
+int SetToolsPath(const char *order, const char *path)
+{
+    FILE *fp_f, *fp_t;
+    if ((fp_f = fopen("config", "r")) == NULL)
+        exit(-1);
+    if ((fp_t = fopen("config_tmp", "w")) == NULL)
+        exit(-1);
+    std::string cmd = order;
+    std::transform(cmd.begin() + 1, cmd.end(), cmd.begin(), toupper);
+    cmd.at(cmd.size() - 1) = '\0';
+    char Command[CMD_NUM];
+    snprintf(Command, CMD_NUM, "<PATH_%s>\t=\t", cmd.c_str());
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp_f))
+    {
+        getline(&Buffer,&Len,fp_f);
+        if(strstr(Buffer, Command) != NULL)
+        {
+            int count = 0;
+            for (int i = 0; i < (int)strlen(Buffer); i++)
+            {
+                if (Buffer[i] == '\t')
+                {
+                    count++;
+                }
+                if (count == 2)
+                {
+                    strncat(Command, path, strlen(path));
+                    snprintf(Buffer, strlen(Command) + 2, "%s\n", Command);
+                    break;
+                }
+            }
+        }
+        fputs(Buffer, fp_t);
+    }
+    fclose(fp_f);
+    fclose(fp_t);
+    remove("config");
+    rename("config_tmp", "config");
+    return 0;
+}
+
+int GetToolsPath(char *path, const char *order)
+{
+    FILE *fp;
+    if ((fp = fopen("config", "r")) == NULL)
+    {
+        printf("config打开失败\n");
+        exit(-1);
+    }
+    std::string cmd = order;
+    std::transform(cmd.begin() + 1, cmd.end(), cmd.begin(), toupper);
+    cmd.at(cmd.size() - 1) = '\0';
+    char Command[CMD_NUM];
+    snprintf(Command, CMD_NUM, "<PATH_%s>\t=\t", cmd.c_str());
+    char *Buffer = NULL;
+    size_t Len = FILE_LINE;
+    while (!feof(fp))
+    {
+        getline(&Buffer,&Len,fp);
+        if(strstr(Buffer, Command) != NULL)
+        {
+            int count = 0;
+            for (int i = 0; i < (int)strlen(Buffer); i++)
+            {
+                if (Buffer[i] == '\t')
+                {
+                    count++;
+                }
+                if (count == 2)
+                {
+                    snprintf(path, strlen(Buffer) +  1, "%s", &Buffer[i+1]);
+                    fclose(fp);
+                    if (path[strlen(path)-1] == '\n')
+                    {
+                        path[strlen(path)-1] = '\0';
+                    }
+                    return 0;
+                }
+            }
+        }
+    }
+    fclose(fp);
+    return 0;
+}
+
+int SetEvmt(int argc, char *argv[])
+{
+    for (int i = 0; i < argc; i++)
+    {
+        std::string cmd = argv[i];
+        if (cmd[0] == '-')
+        {
+            SetToolsPath(argv[i] ,argv[i+1]);
+        }
+
+    }
+    printf("Now, the environment variable is :\n");
+    PrintEvmt();
+    return 0;
+}

--- a/PVCTools_alpha_v2.5/src/headnode/WriteScript.cpp
+++ b/PVCTools_alpha_v2.5/src/headnode/WriteScript.cpp
@@ -1,0 +1,283 @@
+//
+// Created by liujiajun on 2017/4/21.
+//
+
+/////////////////////////////////////////////////////////////////////////////
+//Write the commit script to the node.
+//Command: ./Writescript $Command $WORKPATH $PARAMETERS .... ($QUEUE $CPU $SPAN)
+/////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "Environment.h"
+
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+    // Verify at least one arg.
+    if (argc == 1)
+    {
+        std::cout << " SplitFA              - The source gene sequence FA file is split into small portions according to the included chromosomes." << std::endl;
+        std::cout << " SegmentFA            - Each FA file is segmented into small portions according to the split number." << std::endl;
+        std::cout << " SplitBAM             - The source ratio of the sample BAM file is split into small portions according to the included chromosome." << std::endl;
+        std::cout << " SegmentBAM           - Each BAM file is segmented into small portions according to the split number." << std::endl;
+        std::cout << " Submit               - Submit and calculate VCF results." << std::endl;
+        std::cout << " StitchVCF            - Stitching the calculated VCF file." << std::endl;
+        std::cout << " SmallFA              - Calculate the small chromosome FA files." << std::endl;
+        std::cout << " GetVCF               - 整合运行步骤." << std::endl;
+        std::cout << " Enviroment           - Setting environment variable." << std::endl;
+        std::cout << std::endl;
+    }
+    else if (argc == 2)
+    {
+        std::string cmd = argv[1];
+        if (cmd == "SplitFA" )
+        {
+            std::cout << "\t./PVCTools SplitFA <-w WorkPath> <-fa FAPath> [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-fa              : The path of the original FA file."<< std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "SegmentFA")
+        {
+            std::cout << "\t./PVCTools SegmentFA <-w WorkPath> <-n SplitNumber> [-lm Size] [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-n               : The number of divisions." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-lm              : Minimize the size(MB) of files to be cut(default: Cut all the FA files imported from [falist])." << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << "\tTips:" << std::endl;
+            std::cout << "\tYou may need to customize the FA file list that you want to import in [falist]." << std::endl;
+            std::cout << "\tRunning again will delete the previous data." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "SplitBAM")
+        {
+            std::cout << "\t./PVCTools SplitBAM <-w WorkPath> <-bam BAMPath> [-I] [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-bam             : The path of the original comparison sample BAM files group." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-I               : Will import [bamlist](By default, do not import, all of the BAM files in the target path will be calculated)." << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "SegmentBAM")
+        {
+            std::cout << "\t./PVCTools SegmentBAM <-w WorkPath> <-n SplitNumber> [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-n               : The number of divisions." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << "\tTips:" << std::endl;
+            std::cout << "\tYou may need to customize the FA/BAM file list that you want to import in [falist]." << std::endl;
+            std::cout << "\tRunning again will delete the previous data." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "Submit")
+        {
+            std::cout << "\t./PVCTools Submit <-w WorkPath> [-T Tools] [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-T               : The tool you want to use to run the task (Default tool: samtools)." << std::endl;
+            std::cout << "\t\t                   Optional tools : [samtools] [gatk] [freebayes]." << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << "\tTips:" << std::endl;
+            std::cout << "\tYou may need to customize the FA file list that you want to import in [falist]." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "StitchVCF")
+        {
+            std::cout << "\t./PVCTools StitchVCF <-w WorkPath> <-n SplitNumber> [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-n               : The number of divisions." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << "\tTips:" << std::endl;
+            std::cout << "\tYou may need to customize the FA file list that you want to import in [falist]." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "SmallFA")
+        {
+            std::cout << "\t./PVCTools SmallFA <-w WorkPath> [-T Tools] [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-T               : The tool you want to use to run the task (Default tool: samtools)." << std::endl;
+            std::cout << "\t\t                   Optional tools : [samtools] [gatk] [freebayes]." << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "GetVCF")
+        {
+            std::cout << "\t./PVCTools GetVCF <-w WorkPath> <-fa FAPath> <-bam BAMPath> <-n SplitNumber> [-lm Size] [-I] [-T Tools] [-q Queue] [-cpu CPU] [-span Span]" << std::endl;
+            std::cout << "\tRequired Parameters:" << std::endl;
+            std::cout << "\t\t-w               : Working directory path for using to store the generated files." << std::endl;
+            std::cout << "\t\t-fa              : The path of the original FA file."<< std::endl;
+            std::cout << "\t\t-n               : The number of divisions." << std::endl;
+            std::cout << "\t\t-bam             : The path of the original comparison sample BAM files group." << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-lm              : Minimize the size(MB) of files to be cut(default: Cut all the FA files imported from [falist])." << std::endl;
+            std::cout << "\t\t-I               : Will import [bamlist](By default, do not import, all of the BAM files in the target path will be calculated)." << std::endl;
+            std::cout << "\t\t-T               : The tool you want to use to run the task (Default tool: samtools)." << std::endl;
+            std::cout << "\t\t                   Optional tools : [samtools] [gatk] [freebayes]." << std::endl;
+            std::cout << "\t\t-q               : The queue you want to run the task (Default queue: normal)." << std::endl;
+            std::cout << "\t\t-cpu             : The number of CPUs you want to allocate for running the task (Default value: 1)." << std::endl;
+            std::cout << "\t\t                   Ideal value: The number of samples." << std::endl;
+            std::cout << "\t\t                   BUT considering the CPU resources,this value should be less then the queue CPU maximum." << std::endl;
+            std::cout << "\t\t-span            : The maximum number of the CPU used on each node (Default value: 20)." << std::endl;
+            std::cout << std::endl;
+        }
+        else if (cmd == "Environment")
+        {
+            std::cout << "\t./PVCTools Environment [-samtools PATH] [-bcftools PATH] [-bamUtil PATH]" << std::endl;
+            std::cout << "\tOptional Parameters:" << std::endl;
+            std::cout << "\t\t-samtools        : Setting samtools path." << std::endl;
+            std::cout << "\t\t-bcftools        : Setting bcftools path." << std::endl;
+            std::cout << "\t\t-bamUtil         : Setting bamUtil path." << std::endl;
+            std::cout << std::endl;
+
+            PrintEvmt();
+        }
+        else
+        {
+            std::cout << "Error: Error Parameters." << std::endl;
+            std::cout << "Parameters should be 'SplitFA' 'SegmentFA' 'SplitBAM' 'SegmentBAM' 'Submit' 'StitchVCF' or 'SmallFA'." << std::endl;
+            std::cout << std::endl;
+        }
+    }
+    else
+    {
+        std::string cmd = argv[1];
+        if (cmd == "SplitFA" || cmd == "SegmentFA" || cmd == "SplitBAM" || cmd == "SegmentBAM" || cmd == "Submit" || cmd == "StitchVCF" || cmd == "SmallFA" || cmd == "GetVCF")
+        {
+            char ShellCommand[CMD_NUM];
+
+            char Queue[CMD_NUM] = "normal";
+            char Cpu[CMD_NUM] = "1";
+            char Span[CMD_NUM] = "20";
+            char PathWork[CMD_NUM];
+
+            for (int i = 0; i < argc; i++)
+            {
+                cmd = argv[i];
+                if (cmd == "-w")
+                {
+                    sprintf(PathWork, "%s", argv[i + 1]);
+                }
+                if (cmd == "-q")
+                {
+                    sprintf(Queue, "%s", argv[i + 1]);
+                }
+                if (cmd == "-cpu")
+                {
+                    sprintf(Cpu, "%s", argv[i + 1]);
+                }
+                if (cmd == "-span")
+                {
+                    sprintf(Span, "%s", argv[i + 1]);
+                }
+            }
+            char CurrentPath[CMD_NUM];
+            //Get the current directory.
+            int Count;
+            Count = readlink("/proc/self/exe", CurrentPath, CMD_NUM);
+            if (Count < 0 || Count >= CMD_NUM)
+            {
+                printf("Failed\n");
+                return(EXIT_FAILURE);
+            }
+            for (int i = Count; i >= 0; --i)
+            {
+                if (CurrentPath[i] == '/')
+                {
+                    CurrentPath[i] = '\0';
+                    break;
+                }
+            }
+            FILE *fp_sh;
+            sprintf(ShellCommand, "%s/run.sh", CurrentPath);
+            if ((fp_sh = fopen(ShellCommand, "w")) == NULL)
+                exit(-1);
+            //Write the relevant parameters of the script.
+            sprintf(ShellCommand, "#BSUB -q %s\n", Queue);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -J %s\n", argv[1]);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -o %s/%s.out\n", PathWork, argv[1]);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -e %s/%s.err\n", PathWork, argv[1]);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -n %s\n", Cpu);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -R \"span[ptile=%s]\"\n", Span);
+            fputs(ShellCommand, fp_sh);
+            sprintf(ShellCommand, "#BSUB -a openmpi\n\n\n");
+            fputs(ShellCommand, fp_sh);
+            //mpirun.lsf
+            sprintf(ShellCommand, "%s/bin/./main", CurrentPath);
+            char tmp[CMD_NUM];
+            for (int i = 1; i < argc; i++)
+            {
+                sprintf(tmp, " %s", argv[i]);
+                strcat(ShellCommand, tmp);
+            }
+            fputs(ShellCommand, fp_sh);
+            fclose(fp_sh);
+            //Submit the script.
+            sprintf(ShellCommand, "bsub < %s/run.sh", CurrentPath);
+            system(ShellCommand);
+        }
+        else if(cmd == "Environment")
+        {
+            SetEvmt(argc - 2, argv + 2);
+        }
+        else
+        {
+            std::cout << "Error: Error Parameters." << std::endl;
+            std::cout << "Please check again." << std::endl;
+            std::cout << std::endl;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
1.现在使用命令`make`进行编译安装。代码更新后，重新`make`进行更新。

2.增加模块 Environment，用于设置环境变量samtools、bcftools、bamUtil的路径，以适应不同的运行环境。

2.增加模块 GetVCF，整合了SplitFA、SegmentFA、SplitBAM、SegmentBAM和Submit的功能，可以直接得到分割后的vcf文件。

3.现在程序的相关命令只会计算 [fa]、[bam]、[vcf]后缀的文件，不再错误地计算其他类型的文件或文件夹。

4.修正了fa文件导入染色体名字的错误，解决了SegmenBAM模块的报错问题。

5.模块 Submit  中，增加了对GATK、freebayes 工具的支持。
